### PR TITLE
Fix prometheus metrics text exporter rendering

### DIFF
--- a/src/textexporter.h
+++ b/src/textexporter.h
@@ -118,7 +118,10 @@ struct PrometheusMetric {
                 buf += view.size();
                 space -= view.size();
             }
+            _render<typename Split::Next>(buf, space, val);
+            return;
         }
+
         auto v = std::to_string(val);
         auto ts = std::to_string(photon::now / 1000);
         if (v.size() < space) {


### PR DESCRIPTION
**What this PR does / why we need it**: Iterate through all text chunks that need to be emitted as part of the metric text label section before rendering the value and timestamp. Metric rendering was incorrect and unparsable by prometheus.

**Please check the following list**:
- [ ]  Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [ ]  Does this change require a documentation update?
- [ ]  Does this introduce breaking changes that would require an announcement or bumping the major version?
- [ ]  Do all new files have an appropriate license header?