### PR TITLE
Prevent busy-loop when tcmulib_processing_start fails

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -293,9 +293,14 @@ protected:
         struct tcmulib_cmd *cmd;
         obd_dev *odev = (obd_dev *)tcmu_dev_get_private(dev);
         tcmulib_processing_start(dev);
+        bool got_cmd = false;
         while ((cmd = tcmulib_get_next_command(dev, 0)) != NULL) {
+            got_cmd = true;
             odev->inflight++;
             threadpool.thread_create(&handle, new handle_args{dev, cmd});
+        }
+        if (!got_cmd) {
+            photon::thread_usleep(1000);
         }
         return 0;
     }


### PR DESCRIPTION
When tcmulib_processing_start fails to read the UIO device, it logs an error but produces no commands. Without yielding, the event loop spins at 100% CPU, starving the master netlink loop and preventing new devices from being configured.

Sleep 1ms when no commands are available to break the spin.
