### PR TITLE
Enable uninit_bg (gdt_csum) in ext4 mkfs for fast offline resize

### DIFF
--- a/CMake/Findphoton.cmake
+++ b/CMake/Findphoton.cmake
@@ -2,10 +2,17 @@ include(FetchContent)
 set(FETCHCONTENT_QUIET false)
 set(PHOTON_ENABLE_EXTFS ON)
 
+# Runloop: patch Photon's ext4 mkfs to enable uninitialized block groups
+# (gdt_csum). This lets an offline resize2fs grow of a devbox rootfs mark new
+# inode tables uninitialized instead of zeroing them — a near-instant grow with
+# minimal writes into the layered (COW) block format.
+# Idempotent: skips if the patch is already applied (reverse-check succeeds).
+set(_photon_mkfs_patch "${CMAKE_CURRENT_LIST_DIR}/patches/photon-v0.6.17-ext4-uninit-bg.patch")
 FetchContent_Declare(
   photon
   GIT_REPOSITORY https://github.com/alibaba/PhotonLibOS.git
   GIT_TAG v0.6.17
+  PATCH_COMMAND sh -c "git apply --reverse --check '${_photon_mkfs_patch}' 2>/dev/null || git apply '${_photon_mkfs_patch}'"
 )
 
 if(BUILD_TESTING)

--- a/CMake/patches/photon-v0.6.17-ext4-uninit-bg.patch
+++ b/CMake/patches/photon-v0.6.17-ext4-uninit-bg.patch
@@ -1,0 +1,16 @@
+--- a/fs/extfs/mkfs.cpp	2026-07-22 10:34:58
++++ b/fs/extfs/mkfs.cpp	2026-07-22 10:34:58
+@@ -73,6 +73,13 @@
+     ext2fs_set_feature_flex_bg(&fs_param);
+     ext2fs_set_feature_extents(&fs_param);
+     ext2fs_set_feature_extra_isize(&fs_param);
++    // Runloop: enable uninitialized block groups (gdt_csum). An offline
++    // resize2fs grow then marks new inode tables uninitialized instead of
++    // zeroing them — a near-instant grow with minimal writes into the
++    // layered (COW) block format. (metadata_csum is avoided: it seeds
++    // checksums from s_uuid, which is set after ext2fs_initialize below, so
++    // it would produce an invalid superblock checksum.)
++    ext2fs_set_feature_gdt_csum(&fs_param);
+ 
+     fs_param.s_log_cluster_size = fs_param.s_log_block_size = 2;
+     fs_param.s_desc_size = EXT2_MIN_DESC_SIZE_64BIT;


### PR DESCRIPTION
Patch Photon's `do_mkfs` to set the ext4 `gdt_csum` (uninitialized block groups) feature on the base layer. A guest-side offline `resize2fs` grow of a devbox rootfs then marks new inode tables uninitialized instead of zeroing them — a near-instant, metadata-only grow into the layered (COW) block format instead of writing gigabytes of zeros.

`metadata_csum` is deliberately not used: it seeds checksums from `s_uuid`, which `do_mkfs` sets after `ext2fs_initialize` caches the seed, producing an invalid superblock checksum. `gdt_csum` has no such ordering dependency.

Applied to PhotonLibOS v0.6.17 via a CMake FetchContent `PATCH_COMMAND` in `Findphoton.cmake` (idempotent reverse-check).

Released as tag `v0.0.11-runloop`; consumed by the runloopai/iac blueprint builder images (v0.9.5).