### PR TITLE
fix(mkfs): reserve correct htree checksum tail

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -87,6 +87,13 @@ jobs:
         ls obd_mp
         sudo diff -r --exclude "lost+found" test_data obd_mp
         sudo umount obd_mp
+        mkdir -p htree_data/crowded
+        for i in $(seq 1 1000); do touch "htree_data/crowded/file-${i}"; done
+        tar -cf htree.tar -C htree_data .
+        truncate -s 1g htree.img
+        /opt/overlaybd/bin/overlaybd-apply --mkfs --raw htree.tar htree.img
+        sudo e2fsck -fn htree.img 2>&1 | tee htree-e2fsck.log || true
+        ! grep -F "invalid limit (506)" htree-e2fsck.log
     - name: E2E Test turboOCIv1
       working-directory: ${{github.workspace}}/build
       shell: bash

--- a/CMake/Finde2fs.cmake
+++ b/CMake/Finde2fs.cmake
@@ -1,10 +1,12 @@
 if(NOT ORIGIN_EXT2FS)
     message("Add and build standalone libext2fs")
     include(FetchContent)
+    set(_e2fsprogs_htree_patch "${CMAKE_CURRENT_LIST_DIR}/patches/e2fsprogs-fix-htree-root-limit.patch")
     FetchContent_Declare(
         e2fsprogs
         GIT_REPOSITORY https://github.com/data-accelerator/e2fsprogs.git
         GIT_TAG b4cf6c751196a12b1df9a269d8e0b516b99fe6a7
+        PATCH_COMMAND sh -c "git apply --reverse --check '${_e2fsprogs_htree_patch}' 2>/dev/null || git apply '${_e2fsprogs_htree_patch}'"
     )
     FetchContent_GetProperties(e2fsprogs)
 

--- a/CMake/patches/e2fsprogs-fix-htree-root-limit.patch
+++ b/CMake/patches/e2fsprogs-fix-htree-root-limit.patch
@@ -1,0 +1,16 @@
+diff --git a/lib/ext2fs/expanddir.c b/lib/ext2fs/expanddir.c
+index 898a362c..d86d695e 100644
+--- a/lib/ext2fs/expanddir.c
++++ b/lib/ext2fs/expanddir.c
+@@ -185,7 +185,10 @@ static errcode_t make_indexed_dir(ext2_filsys fs, ext2_ino_t dir, struct ext2_i
+     entries = root->entries;
+     entries->block = ext2fs_cpu_to_le32(1);
+     ((struct ext2_dx_countlimit *) entries)->count = ext2fs_cpu_to_le16(1);
+-    ((struct ext2_dx_countlimit *) entries)->limit = ext2fs_cpu_to_le16((blocksize - (32 + csum_size)) / sizeof(struct ext2_dx_entry));
++    ((struct ext2_dx_countlimit *) entries)->limit = ext2fs_cpu_to_le16(
++        (blocksize - 32 -
++         (csum_size ? sizeof(struct ext2_dx_tail) : 0)) /
++        sizeof(struct ext2_dx_entry));
+ 
+     /* write out blocks */
+     for (int i = 0; i < dx_info.levels; i++)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes corrupt ext4 directory indexes created when `metadata_csum` is enabled. The pinned e2fsprogs fork reserved a 12-byte directory-entry checksum tail in an HTREE root, but HTREE roots use an 8-byte `ext2_dx_tail`. On 4 KiB filesystems this wrote limit 506 where the kernel and e2fsck require 507.

Adds an E2E regression that converts a directory with 1,000 entries and requires `e2fsck -fn` to pass.

**Please check the following list**:
- [x] Does the affected code have corresponding tests, e.g. unit test, E2E test?
- [x] Does this change require a documentation update? No.
- [x] Does this introduce breaking changes that would require an announcement or bumping the major version? No.
- [x] Do all new files have an appropriate license header? The new file is a patch to the existing LGPL source.